### PR TITLE
confusion about root directories, x86 for H100, cleanenv

### DIFF
--- a/llm_training/llm_benchmark_nvidia_amd.yaml
+++ b/llm_training/llm_benchmark_nvidia_amd.yaml
@@ -383,25 +383,31 @@ parameterset:
         tag: "JEDI+!container"
         separator: |
         _: |
-          --cpu_bind=v --mpi=pmi2 apptainer exec  --bind=${jube_benchmark_home},${root_dir} --nv ${singularity_file} ${root_dir}/nvidia_arm_torch_wrap.sh
+          --cpu_bind=v --mpi=pmi2 apptainer exec --cleanenv --bind=${jube_benchmark_home},${root_dir} --nv ${singularity_file} ${BENCH_DIR}/nvidia_arm_torch_wrap.sh
       - name: args_starter
         mode: text
         tag: "!(JEDI|MI250|GH200|H100)+!container"
         separator: |
         _: |
-          --disable-dcgm --cpu_bind=v --mpi=pspmix env PMIX_SECURITY_MODE=native apptainer exec --bind=${jube_benchmark_home},${root_dir} --nv ${singularity_file} ${root_dir}/nvidia_x86_torch_wrap.sh
+          --disable-dcgm --cpu_bind=v --mpi=pspmix env PMIX_SECURITY_MODE=native apptainer exec --cleanenv --bind=${jube_benchmark_home},${root_dir} --nv ${singularity_file} ${BENCH_DIR}/nvidia_x86_torch_wrap.sh
       - name: args_starter
         mode: text
-        tag: "(GH200|H100)+!container"
+        tag: "GH200+!container"
         separator: |
         _: |
-          --cpu_bind=v --mpi=pspmix env PMIX_SECURITY_MODE=native apptainer exec --bind=${jube_benchmark_home},${root_dir} --nv ${singularity_file} ${root_dir}/nvidia_arm_torch_wrap.sh
+          --cpu_bind=v --mpi=pspmix env PMIX_SECURITY_MODE=native apptainer exec --cleanenv --bind=${jube_benchmark_home},${root_dir} --nv ${singularity_file} ${BENCH_DIR}/nvidia_arm_torch_wrap.sh
+      - name: args_starter
+        mode: text
+        tag: "H100+!container"
+        separator: |
+        _: |
+          --cpu_bind=v --mpi=pspmix env PMIX_SECURITY_MODE=native apptainer exec --cleanenv --bind=${jube_benchmark_home},${root_dir} --nv ${singularity_file} ${BENCH_DIR}/nvidia_x86_torch_wrap.sh
       - name: args_starter
         mode: text
         tag: "MI250+!container"
         separator: |
         _: |
-          --cpu_bind=none,v --mpi=pspmix env PMIX_SECURITY_MODE=native apptainer exec --bind=${jube_benchmark_home},${root_dir} ${singularity_file} ${root_dir}/amd_torch_wrap.sh
+          --cpu_bind=none,v --mpi=pspmix env PMIX_SECURITY_MODE=native apptainer exec --cleanenv --bind=${jube_benchmark_home},${root_dir} ${singularity_file} ${BENCH_DIR}/amd_torch_wrap.sh
 
 patternset:
    - name: perf_patterns

--- a/llm_training/setup_nvidia_llm.sh
+++ b/llm_training/setup_nvidia_llm.sh
@@ -30,11 +30,11 @@ echo "ACCELERATOR=$ACCELERATOR"
 
 if ! [ -f "$BENCH_DIR"/nvidia_x86_torch_wrap.sh ] && [[ " ${NVIDIA_X86_ACCELERATORS[@]} " == *" $ACCELERATOR "* ]]; then
     echo "creating NVIDIA X86 wrapper"
-    printf "%s\n"  "export PYTHONPATH=$BENCH_DIR/nvidia_x86_torch_packages/local/lib/python3.10/dist-packages:\$PYTHONPATH" "\$*" > "$BENCH_DIR"/nvidia_x86_torch_wrap.sh
+    printf "%s\n"  "export PYTHONPATH=$BENCH_DIR/../nvidia_x86_torch_packages/local/lib/python3.10/dist-packages:\$PYTHONPATH" "export CUDA_DEVICE_MAX_CONNECTIONS=1" "\$*" > "$BENCH_DIR"/nvidia_x86_torch_wrap.sh
     chmod u+rwx "$BENCH_DIR"/nvidia_x86_torch_wrap.sh
 elif ! [ -f "$BENCH_DIR"/nvidia_arm_torch_wrap.sh ] && [[ " ${NVIDIA_ARM_ACCELERATORS[@]} " == *" $ACCELERATOR "* ]]; then
     echo "creating NVIDIA ARM wrapper"
-    printf "%s\n"  "export PYTHONPATH=$BENCH_DIR/nvidia_arm_torch_packages/local/lib/python3.10/dist-packages:\$PYTHONPATH" "\$*" > "$BENCH_DIR"/nvidia_arm_torch_wrap.sh
+    printf "%s\n"  "export PYTHONPATH=$BENCH_DIR/../nvidia_arm_torch_packages/local/lib/python3.10/dist-packages:\$PYTHONPATH" "export CUDA_DEVICE_MAX_CONNECTIONS=1" "\$*" > "$BENCH_DIR"/nvidia_arm_torch_wrap.sh
     chmod u+rwx "$BENCH_DIR"/nvidia_arm_torch_wrap.sh
 fi
 


### PR DESCRIPTION
There were some issues when I tried to set the framework up. I made some changes to get it to run, but please see if this makes sense overall, or there are more elegant ways to fix these. Or maybe everything is already fixed in a branch, I only looked at main, and only at NVIDIA.

1. For H100 (JURECA evaluation platform), it is looking for the wrong pytorch wrapper (arm instead of x86).  To fix this, I separated the executeset for the tag "(GH200|H100)+!container" into two, where in the case of H100, one looks for x86 wrapper. 
2. There is some inconsistency with the use of the variables root_dir vs BENCH_DIR. BENCH_DIR is a subdirectory (e.g. `llm_training`) in root_dir.
    * The wrapper is stored in $BENCH_DIR. See https://github.com/FZJ-JSC/CARAML/blob/8788cef131fda72cdc109b70d706a81d863a04b0/llm_training/setup_nvidia_llm.sh#L33
    * But the jube file looks for the wrapper in $root_dir. See https://github.com/FZJ-JSC/CARAML/blob/8788cef131fda72cdc109b70d706a81d863a04b0/llm_training/llm_benchmark_nvidia_amd.yaml#L392. 
    * The python packages are installed into $root_dir/nvidia_x86_torch_packages (in x86 case). See https://github.com/FZJ-JSC/CARAML/blob/8788cef131fda72cdc109b70d706a81d863a04b0/get_pytorch_container.sh#L26
    * But the PYTHONPATH in the wrapper is set to find the python packages in $BENCH_DIR. See https://github.com/FZJ-JSC/CARAML/blob/8788cef131fda72cdc109b70d706a81d863a04b0/llm_training/setup_nvidia_llm.sh#L33
3. I had to use `--cleanenv` as an apptainer flag in the srun calls. Otherwise I would get errors about missing site packages, like   ModuleNotFoundError: No module named 'regex._regex’

I fixed this by changing the srun lines to look for the wrapper in $BENCH_DIR.  And by changing the PYTHONPATH line from `$BENCH_DIR` to `$BENCH_DIR/..`. But this feels unelegant. Another possibility would be to install the packages to $BENCH_DIR instead, i.e. adapting setup_nvidia_llm. 

Another thing: The meaning and use of the `container` tag should be put into the README.  That it refers to building the containers, and you need to do it once, before you do the actual benchmark run. Maybe consider renaming it to "build-container", because otherwise it can be misunderstood to mean "should containers be used during the benchmark".

Hope, you find these suggestions helpful!
    